### PR TITLE
Exclude Travis JDK 7 run for latest Camunda versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,7 @@ jobs:
   exclude:
     - jdk: oraclejdk7
       env: CAMUNDA=LATEST
+    - jdk: oraclejdk7
+      env: CAMUNDA=7.12.0
 install: true
 script: mvn -Dcamunda-bpm.version=$CAMUNDA

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ jdk:
   - oraclejdk7
 env:
   - CAMUNDA=LATEST
-  - CAMUNDA=RELEASE
   - CAMUNDA=7.12.0
   - CAMUNDA=7.11.0
   - CAMUNDA=7.10.0
@@ -20,5 +19,9 @@ env:
   - CAMUNDA=7.2.0
   - CAMUNDA=7.1.0-Final
   - CAMUNDA=7.0.0-Final  
+jobs:
+  exclude:
+    - jdk: oraclejdk7
+      env: CAMUNDA=LATEST
 install: true
 script: mvn -Dcamunda-bpm.version=$CAMUNDA


### PR DESCRIPTION
Due to end of support for Java 7 we exclude the latest versions from being tested with Java 7.