### PR TITLE
Change external task lock time to Integer.MAX_VALUE ensuring Oracle compatibility

### DIFF
--- a/core/src/main/java/org/camunda/bpm/scenario/impl/waitstate/ServiceTaskExecutable.java
+++ b/core/src/main/java/org/camunda/bpm/scenario/impl/waitstate/ServiceTaskExecutable.java
@@ -32,7 +32,7 @@ public class ServiceTaskExecutable extends AbstractExternalTaskDelegate {
   }
 
   protected void fetchAndLock() {
-    getExternalTaskService().fetchAndLock(Integer.MAX_VALUE, WORKER_ID).topic(getDelegate().getTopicName(), Long.MAX_VALUE).execute();
+    getExternalTaskService().fetchAndLock(Integer.MAX_VALUE, WORKER_ID).topic(getDelegate().getTopicName(), Integer.MAX_VALUE).execute();
   }
 
   @Override


### PR DESCRIPTION
Fixes #40 please let me know if you have any suggestions.