### PR TITLE
Update example for mocking call activities

### DIFF
--- a/example/src/test/java/org/camunda/bpm/scenario/examples/insuranceapplication/InsuranceApplicationProcessTest.java
+++ b/example/src/test/java/org/camunda/bpm/scenario/examples/insuranceapplication/InsuranceApplicationProcessTest.java
@@ -75,7 +75,7 @@ public class InsuranceApplicationProcessTest {
     });
 
     when(insuranceApplication.runsCallActivity("CallActivityDocumentRequest"))
-      .thenReturn(Scenario.use(documentRequest));
+      .thenAnswer(invocation -> Scenario.use(documentRequest));
 
     when(documentRequest.waitsAtSendTask("SendTaskRequestDocuments")).thenReturn((externalTask) -> {
       assertThat(externalTask).hasTopicName("SendMail");


### PR DESCRIPTION
Before this commit, the example used `thenReturn` to mock call activities with a scenario. This worked well if the call activity is called only once. However, if the call activity would be called multiple times, the same scenario (as in "same Java object") would be reused. If users would copy this example into their own code, they could observe unexpected behaviour in their tests when calling activities multiple times.

This commit changes the example to use `thenAnswer` to create a new scenario (with equal behaviour) for each call.